### PR TITLE
Set max star for achievement.lockPopup() on 528 to 40

### DIFF
--- a/achievements.js
+++ b/achievements.js
@@ -121,7 +121,7 @@ achievement.maxForLocks = {
 	},
 	stars:{
 		516:0,
-		528:0,
+		528:40,
 		609:0,
 		707:0,
 		get 711(){return Math.min(39-achievement(711).milestones(),40)},


### PR DESCRIPTION
Change achievement.maxForLocks.stars[528] from 0 to 40. This allows buying a max of 40-stars for the progressbar-lock at ach528 (previously set to 0)