### PR TITLE
𝕍1ω.14a : The "Nitpicky-Fix"-Fix

### DIFF
--- a/achievements.js
+++ b/achievements.js
@@ -1242,7 +1242,8 @@ const achievementList = {
 		614:{
 			name:"Redstone Clock",
 			description:"Have each of the last 10 Wormhole resets be less than or equal to 1 second long",
-			check:function(){return (g.previousWormholeRuns.last10.length===10)&&(!g.previousWormholeRuns.last10.map(x=>x.time<=1).includes(false))},
+			check:function(){return (g.previousWormholeRuns.last10.length==10)&&(!g.previousWormholeRuns.last10.map(x=>parseFloat(x.time.toFixed(14))<=1.0).includes(false))},
+			/* check the float down to e-14, allowing up to 10 femtoseconds of buffer, making it less "nitpicky" */
 			prevReq:[510],
 			event:"wormholeResetAfter",
 			progress:function(){return (g.previousWormholeRuns.last10.length===10)?{percent:achievement.percent(N(this.time()),c.d1,x=>x.recip()),text:"Slowest run is "+timeFormat(this.time())}:("Do 10 Wormhole resets first (currently: "+g.previousWormholeRuns.last10.length+")")},

--- a/changelog.html
+++ b/changelog.html
@@ -78,6 +78,9 @@ const logEntries = [
 
 	]},
 	*/
+	{num:"𝕍1ω.14a",date:"2026-04-01",name:"There is still someone working on this game!",changes:[
+		[6,"BUGFIX","Achievement 614 \"Redstone Clock\" is now definetly less nitpicky","Hedrauta"]
+	]},
 	{num:"𝕍1ω.14",date:"2026-04-01",name:"Is There Anyone Else Still Working On This Game?",changes:[
 		[5,"BUGFIX","Achievement 528 \"Grand Balance\" lock now works correctly.","Hedrauta"],
 		[1,"WHAT","Progress bar percentage is now 71%."]


### PR DESCRIPTION
Adjust Achievement 614's time comparison to avoid false negatives from floating-point precision:

Allows the verification a tolerance of 10 femtoseconds (1e-14) . We don't want to be too picky, right? 😜